### PR TITLE
feat: 射水市の人口データPDFを一括変換するpipelineを試作

### DIFF
--- a/data_extraction_step.py
+++ b/data_extraction_step.py
@@ -1,0 +1,76 @@
+import pandas as pd
+import camelot
+import fitz  # PyMuPDF
+import glob
+import os
+
+
+class DataExtractionStep:
+    def __init__(self, name, step_type, config):
+        self.name = name
+        self.step_type = step_type
+        self.config = config
+
+    def execute(self):
+        input_dir = self.config['input_dir']
+        output_dir = self.config['output_dir']
+
+        # ディレクトリが存在しない場合は作成
+        os.makedirs(input_dir, exist_ok=True)
+        os.makedirs(output_dir, exist_ok=True)
+        # データ抽出の実装...
+        self.imizu_pop_norm(input_dir,output_dir)
+
+
+    def imizu_pop_norm(self,input_folder, output_folder):
+        """
+        指定されたフォルダ内の全てのPDFファイルを処理する関数。
+        """
+        # 指定されたフォルダ内の全てのPDFファイルを検索
+        pdf_files = glob.glob(os.path.join(input_folder, '*.pdf'))
+    
+        for pdf_path in pdf_files:
+            self.process_pdf_file(pdf_path, output_folder)
+
+    def process_pdf_file(self,pdf_path, output_folder):
+        """
+        指定されたPDFファイルからデータを抽出し、CSVファイルとして出力する関数。
+        """
+        # PDFから表を抽出
+        tables = camelot.read_pdf(pdf_path, pages="1-end", flavor='stream')
+    
+        # データフレームの初期化
+        age_data = {'年齢': [], '男': [], '女': [], '計': []}
+    
+        # 各ページの表からデータを抽出
+        for table in tables:
+            df = table.df  # 表をデータフレームとして取得
+            for i, row in df.iterrows():
+                if i < 2 or not row[0].strip():
+                    continue
+                for j in range(0, len(row), 4):
+                    if not row[j].strip():
+                        continue
+                    age = row[j].strip().replace(' ', '')
+                    if age == '計':
+                        continue
+                    male = row[j+1].strip().replace(' ', '')
+                    female = row[j+2].strip().replace(' ', '')
+                    total = row[j+3].strip().replace(' ', '')
+                    age_data['年齢'].append(age)
+                    age_data['男'].append(male)
+                    age_data['女'].append(female)
+                    age_data['計'].append(total)
+    
+        # データフレームを作成
+        age_df = pd.DataFrame(age_data)
+        age_df['年齢'] = pd.to_numeric(age_df['年齢'], errors='coerce')
+        age_df_sorted_correct_order = age_df.sort_values(by='年齢').reset_index(drop=True)
+    
+        # 出力ファイル名を設定
+        output_filename = os.path.splitext(os.path.basename(pdf_path))[0] + '.csv'
+        correct_order_csv_path = os.path.join(output_folder, output_filename)
+    
+        # CSVとして出力
+        age_df_sorted_correct_order.to_csv(correct_order_csv_path, index=False)
+        print(f"CSVファイルが作成されました: {correct_order_csv_path}")

--- a/download_config.json
+++ b/download_config.json
@@ -1,0 +1,55 @@
+{
+    "title": "射水市の人口・世帯",
+    "description": "射水市のオープンデータサイトから、人口・世帯に関するPDFを取得する",
+    "files": [
+        {
+            "title": "令和5年4月（日本人）",
+            "url": "https://www.city.imizu.toyama.jp/appupload/EDIT/118/118332.pdf",
+            "cache_url": "",
+            "attribution": "射水市　市民課",
+            "license": "表記なし",
+            "filename": "118332jp.pdf"
+        },
+        {
+            "title": "令和5年5月（日本人）",
+            "url": "https://www.city.imizu.toyama.jp/appupload/EDIT/119/119995.pdf",
+            "cache_url": "",
+            "attribution": "射水市　市民課",
+            "license": "表記なし",
+            "filename": "119995jp.pdf"
+        },
+        {
+            "title": "令和5年6月（日本人）",
+            "url": "https://www.city.imizu.toyama.jp/appupload/EDIT/120/120003.pdf",
+            "cache_url": "",
+            "attribution": "射水市　市民課",
+            "license": "表記なし",
+            "filename": "120003jp.pdf"
+        },
+        {
+            "title": "令和5年7月（日本人）",
+            "url": "https://www.city.imizu.toyama.jp/appupload/EDIT/120/120633.pdf",
+            "cache_url": "",
+            "attribution": "射水市　市民課",
+            "license": "表記なし",
+            "filename": "120633jp.pdf"
+        },
+        {
+            "title": "令和5年8月（日本人）",
+            "url": "https://www.city.imizu.toyama.jp/appupload/EDIT/121/121348.pdf",
+            "cache_url": "",
+            "attribution": "射水市　市民課",
+            "license": "表記なし",
+            "filename": "121348jp.pdf"
+        },
+        {
+            "title": "令和5年9月（日本人）",
+            "url": "https://www.city.imizu.toyama.jp/appupload/EDIT/122/122029.pdf",
+            "cache_url": "",
+            "attribution": "射水市　市民課",
+            "license": "表記なし",
+            "filename": "122029jp.pdf"
+        }
+    ]
+}
+

--- a/download_step.py
+++ b/download_step.py
@@ -1,0 +1,36 @@
+import requests
+import os
+import json
+
+class DownloadStep:
+    def __init__(self, name, step_type, step_config):
+        self.name = name
+        self.step_type = step_type
+        # `config`が文字列（ファイルパス）の場合、その内容を読み込む
+        with open(step_config['config'], 'r') as f:
+            self.config_json = json.load(f)
+        self.download_dir = step_config['download_dir']
+        # ダウンロードディレクトリが存在しない場合は作成
+        os.makedirs(self.download_dir, exist_ok=True)
+
+    def download_file(self, url, save_path):
+        """指定されたURLからファイルをダウンロードし、指定されたパスに保存する"""
+        try:
+            response = requests.get(url, stream=True)
+            response.raise_for_status()  # ステータスコードが200以外の場合は例外を発生させる
+            with open(save_path, 'wb') as f:
+                for chunk in response.iter_content(chunk_size=8192):
+                    f.write(chunk)
+            print(f"File downloaded successfully: {save_path}")
+        except requests.RequestException as e:
+            print(f"Failed to download {url}: {e}")
+
+    def execute(self):
+        """ダウンロードステップを実行する"""
+
+        for file in self.config_json['files']:
+            url = file['url']
+            filename = file['filename']
+            save_path = os.path.join(self.download_dir, filename)
+            self.download_file(url, save_path)
+

--- a/pipeline.yaml
+++ b/pipeline.yaml
@@ -1,0 +1,10 @@
+steps:
+  - name: OpenDataDownload
+    type: download
+    config: download_config.json
+    download_dir: ./input_dir
+  - name: Imizu-Shi PDF converter
+    type: data_extraction
+    config: 
+    input_dir: ./input_dir
+    output_dir: ./output_dir

--- a/pipeline_framework.py
+++ b/pipeline_framework.py
@@ -1,0 +1,22 @@
+from step_factory import StepFactory
+import yaml
+
+# ステップクラスのインポート
+from download_step import DownloadStep
+from data_extraction_step import DataExtractionStep
+
+# ステップをファクトリーに登録
+StepFactory.register_step('download', DownloadStep)
+StepFactory.register_step('data_extraction', DataExtractionStep)
+
+def execute_pipeline(pipeline_config_path):
+    with open(pipeline_config_path, 'r') as file:
+        pipeline_config = yaml.safe_load(file)
+
+    for step_config in pipeline_config.get('steps', []):
+        step = StepFactory.create_step(step_config['type'], step_config['name'], step_config['type'], step_config)
+        step.execute()
+
+if __name__ == "__main__":
+    execute_pipeline('pipeline.yaml')
+

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,6 @@
+pandas==2.1.4
+camelot==0.9.0
+fitz==1.23.8
+requests==2.31.0
+yaml==6.0.1
+

--- a/step_factory.py
+++ b/step_factory.py
@@ -1,0 +1,15 @@
+class StepFactory:
+    _steps = {}
+
+    @classmethod
+    def register_step(cls, step_type, step_class):
+        cls._steps[step_type] = step_class
+
+    @classmethod
+    def create_step(cls, step_type, *args, **kwargs):
+        step_class = cls._steps.get(step_type)
+        if step_class is not None:
+            return step_class(*args, **kwargs)
+        else:
+            raise ValueError(f"Step type {step_type} not registered")
+


### PR DESCRIPTION
射水市の人口データPDFをダウンロードからcsv変換まで行うpipelineを試作。
これをベースに北九州市や他の自治体、他のデータセットに拡張できるよう、pipelineとLibraryを整理する。